### PR TITLE
[Premake] Fixed gtest not being cloned if a parent folder existed

### DIFF
--- a/Premake/external_dependencies.lua
+++ b/Premake/external_dependencies.lua
@@ -1,11 +1,17 @@
 function FetchGoogleTest() 
-    local gtestPath = directories.externalInclude.."gtest/"
+    local gtestPath = directories.externalInclude.."gtest\\"
+    local gitFolderPath = gtestPath..".git\\"
 
-    if not os.isdir(gtestPath) then
-        print("\nCloning GoogleTest into " .. gtestPath .. " ...")
-        os.execute("git clone --depth 1 https://github.com/google/googletest.git " .. gtestPath)
-    else
+    if os.isdir(gtestPath) and os.isdir(gitFolderPath) then
         print("\nUpdating GoogleTest in " .. gtestPath .. " ...")
         os.execute("cd " .. gtestPath .. " && git pull")
+        return
+    else if(os.isdir(gtestPath)) then
+        print("\ngtest dir exist but is empty, removing...["..gtestPath.."]")
+        os.rmdir(gtestPath)
     end
+    
+    print("\nCloning GoogleTest into " .. gtestPath .. " ...")
+    os.execute("git clone --depth 1 https://github.com/google/googletest.git " .. gtestPath)
+end
 end

--- a/Premake/premake5.lua
+++ b/Premake/premake5.lua
@@ -2,6 +2,16 @@ print("Starting premake process")
 include "common.lua"
 include "external_dependencies.lua"
 
+-- a little bit janky but gets to job done
+local includeTests = false
+
+-- loops through the arguments and checks for matches
+    for i, arg in ipairs(_ARGS) do
+        if(arg == "tests") then
+            includeTests = true
+        end
+    end
+
 workspace(WORKSPACE_NAME)
     location(directories.root)
     startproject(PROJECT_NAME)
@@ -17,22 +27,12 @@ print("Setting up folder structure")
 MakeFolderStructure()
 
 print("Including other directories")
-
+    
 include(directories.external)
 include(directories.editor)
 include(directories.core)
 
--- a little bit janky but gets to job done
-local includeTests = false
-
--- loops through the arguments and checks for matches
-for i, arg in ipairs(_ARGS) do
-    if(arg == "tests") then
-        includeTests = true
-    end
-end
-
-
+    
 if(includeTests) then
     FetchGoogleTest()
     
@@ -40,7 +40,7 @@ if(includeTests) then
     include(directories.editorTest)
     include(directories.coreTest)
 end
-
+    
 include(directories.project)
 
 print("\nBuild complete, happy developing!\n")


### PR DESCRIPTION
**Issue:** 
Premake creates all the necessary include directories, this includes gtest directory since it has to be included in the test modules. The issue here was that premake create an empty gtest folder `external/include/gtest` which it later checked if it existed to determine if it should update gtest or clone it.

**Solution:**
It not checks for the `.git` folder inside of `external/include/gtest/` and if it's missing it removes the directory and clones it anew