### PR TITLE
Premake creates errors when creating external directories

### DIFF
--- a/Premake/common.lua
+++ b/Premake/common.lua
@@ -63,11 +63,15 @@ directories = {
     debugLib        = sourcePath .. "External\\Lib\\Debug\\",
     releaseLib      = sourcePath .. "External\\Lib\\Release\\",
 
-    -- Tests
+
+    premake         = basePath .. "Premake",
+ }
+
+ externalDirectories = {
+    -- gtest
     gtestInclude    = sourcePath .. "External\\Include\\googleTest\\googletest\\include\\",
     gtestSrc        = sourcePath .. "External\\Include\\googleTest\\googletest\\",
 
-    premake         = basePath .. "Premake",
  }
 
 function MakeFolderStructure()

--- a/Premake/premake5.lua
+++ b/Premake/premake5.lua
@@ -21,6 +21,9 @@ workspace(WORKSPACE_NAME)
         RELEASE_BUILD_NAME
     }
 
+print("Create folder structure")
+
+MakeFolderStructure()
 
 print("Including other directories")
     

--- a/Premake/premake5.lua
+++ b/Premake/premake5.lua
@@ -21,9 +21,6 @@ workspace(WORKSPACE_NAME)
         RELEASE_BUILD_NAME
     }
 
-print("Setting up folder structure")
-
-MakeFolderStructure()
 
 print("Including other directories")
     

--- a/Source/CoreTests/premake5.lua
+++ b/Source/CoreTests/premake5.lua
@@ -19,16 +19,16 @@ project(NAME)
     files {
         directories.coreTest.."**.h",
         directories.coreTest.."**.cpp",
-        directories.gtestSrc.."src\\gtest_main.cc",
-        directories.gtestSrc.."src\\gtest-all.cc",
+        externalDirectories.gtestSrc.."src\\gtest_main.cc",
+        externalDirectories.gtestSrc.."src\\gtest-all.cc",
     }
 
     includedirs {
         directories.externalInclude,
         directories.core,
 
-        directories.gtestInclude,
-        directories.gtestSrc,
+        externalDirectories.gtestInclude,
+        externalDirectories.gtestSrc,
 
         directories.coreTest,
     }

--- a/Source/EditorTests/premake5.lua
+++ b/Source/EditorTests/premake5.lua
@@ -19,16 +19,16 @@ project(NAME)
     files {
         directories.editorTest.."**.h",
         directories.editorTest.."**.cpp",
-        directories.gtestSrc.."src\\gtest_main.cc",
-        directories.gtestSrc.."src\\gtest-all.cc",
+        externalDirectories.gtestSrc.."src\\gtest_main.cc",
+        externalDirectories.gtestSrc.."src\\gtest-all.cc",
     }
 
     includedirs {
         directories.externalInclude,
         directories.core,
 
-        directories.gtestInclude,
-        directories.gtestSrc,
+        externalDirectories.gtestInclude,
+        externalDirectories.gtestSrc,
 
         directories.editor,
         directories.editorTest,

--- a/Source/Tests/premake5.lua
+++ b/Source/Tests/premake5.lua
@@ -1,8 +1,0 @@
-include "../../Premake/common.lua"
-print("Setting up Tests")
-
-project(TESTS_NAME)
-    location(directories.temp)
-    language("C++")
-    cppdialect(cppVersion)
-    kind("")


### PR DESCRIPTION
Premake created directories for external git submodules which interfered when submodules initialized for the first time. 
Moved external dependencies to it's own variable to avoid letting premake set up a skeleton structure for them