### PR TITLE
Separated build batch scripts

### DIFF
--- a/update_project.bat
+++ b/update_project.bat
@@ -1,0 +1,2 @@
+call "Premake/premake5" --file=Premake/premake5.lua vs2022
+pause


### PR DESCRIPTION
Added `update_project.bat` that only runs the premake pipeline in comparison to `generate_project.bat` that also updated submodules and other external dependencies 